### PR TITLE
Support exporting to new files in Drive, and improved handling of bold and italic formatting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,39 @@
 gdocs2md
 ========
 
-A simple Google Apps script to convert a properly formatted Google Drive Document to the markdown (.md) format. 
+A simple Google Apps script to convert a properly formatted Google Drive Document to the markdown (.md) format.
 
 ## Usage
 
-  * Adding this script to your doc (once per doc):
-    * Open your Google Drive document (http://drive.google.com)
-    * Tools -> Script Manager > New
-    * Select "Blank Project", then paste this code in and save.
-    * Clear the myFunction() default empty function and paste the contents of [converttomarkdown.gapps](https://raw.github.com/mangini/gdocs2md/master/converttomarkdown.gapps) into the code editor
-    * File -> Save
-    
-  * Running the script (run as many times as you want):
-    - Tools > Script Manager
-    - Select "ConvertToMarkdown" function.
-    - Click Run button (First run will require you to authorize it. Authorize and run again)
-    - Converted doc with images attached will be emailed to you. Subject will be "[MARKDOWN_MAKER]...".
+### Adding to a document
+This script must be added to a document to run it - the document doesn't need to be the one you wish to export:
+ 1. Tools > Script Editor > New
+ 2. Select "Blank Project", then paste this code in and save.
 
+### Preparing files
+Put all documents you wish to convert into category folders within a folder in your docs list, called "DocsToConvertToMarkdown". Each category folder can contain multiple documents. You can use just one category folder, e.g. "default" if you don't want to use categories.
+
+### Running the script
+1. Tools > Script Manager
+2. Select "convertDefaultFolder()" function.
+3. Click Run button.
+4. All documents in the folder will be converted to markdown, and resulting files put in a new subfolder called "ExportedMarkdown-TIMESTAMP" where TIMESTAMP is the current ISO GMT timestamp.
+
+### Settings
+There are several optional features, convertDefaultFolder() runs with most features enabled, however most other functions take a settings object. The following fields should be set to true to enable the corresponding features:
+ * **markdownTables** - Output tables in GitHub-Flavoured Markdown rather than HTML. This also supports bold and italic formatting, and inline code blocks, within table cells.
+
+ * **plainTextOutput** - Output markdown to plaintext files (type "text/plain" with .txt extension),allowing for viewing directly in Google Docs. If this is not specified, files will be have type "text/x-markdown" and .md extension.
+
+ * **boldItalicIsQuote** - Any lines starting with bold+italic formatting will become block quotes in the markdown output.
+
+ * **codeBlocks** - Any lines starting with a tab and then containing at least one courier-new formatted character will be considered as code lines. In addition, any empty or whitespace-only lines following a code line will be considered to be code lines. Runs of code lines will be output with three backticks before and after the run, and with the first tab (if any) removed from each line, to form a standard markdown code block.
+
+### Using different folders
+You can call convertFolderByName(folderName, settings) with a different folder name as required
+
+### Miscellaneous
+There are also functions for emailing documents, see source for details.
 
 ## Interpreted formats
   * Text:
@@ -32,28 +48,27 @@ A simple Google Apps script to convert a properly formatted Google Drive Documen
     * images are correctly extracted and sent as attachments
   * Blocks:
     * Table of contents is replaced by `[[TOC]]`
-    * blocks of text delimited by "--- class whateverclassnameyouwant" and "---" are converted to `<div class="whateverclassnameyouwant"></div>` 
-    * Source code: 
+    * blocks of text delimited by "--- class whateverclassnameyouwant" and "---" are converted to `<div class="whateverclassnameyouwant"></div>`
+    * Source code:
       * **UPDATED**: blocks of text delimited by "--- source code" or "--- src" and "---" are converted to `<pre></pre>`
       * **NEW**: blocks of text delimited by "--- source pretty" or "--- srcp" and "---" are converted to `<pre class="prettyprint"></pre>`
     * Tables:
       * **NEW**: Simple `<table>` processing
   * "--- jsperf `<testID>`" is replaced by an iframe that shows an interactive chart of a JSPerf test. The `<testID>` is the last part of the URL of the Browserscope anchor in your JSPerf test. Something like `"agt1YS1wcm9maWxlcnINCxIEVGVzdBjlm_EQDA"` in the URL `http://www.browserscope.org/user/tests/table/agt1YS1wcm9maWxlcnINCxIEVGVzdBjlm_EQDA`
- 
-
 
 ## CONTRIBUTORS
 
 * Renato Mangini - [G+](//google.com/+renatomangini) - [Github](//github.com/mangini)
 * Ed Bacher - [G+](//plus.google.com/106923847899206957842) - [Github](//github.com/evbacher)
+* Ben Webster - [Github](//github.com/trepidacious)
 
 ## LICENSE
 
-Use this script at your will, on any document you want and for any purpose, commercial or not. 
-The MarkDown files generated by this script are not considered derivative work and 
-don't require any attribution to the owners of this script. 
+Use this script at your will, on any document you want and for any purpose, commercial or not.
+The MarkDown files generated by this script are not considered derivative work and
+don't require any attribution to the owners of this script.
 
-If you want to modify and redistribute the script (not the converted documents - those are yours), 
+If you want to modify and redistribute the script (not the converted documents - those are yours),
 just keep a reference to this repo or to the license info below:
 
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A simple Google Apps script to convert a properly formatted Google Drive Documen
 ### Adding to a document
 This script must be added to a document to run it - the document doesn't need to be the one you wish to export:
  1. Tools > Script Editor > New
- 2. Select "Blank Project", then paste this code in and save.
+ 2. Select "Blank Project", then paste the code from converttomarkdown.js into it and save.
 
 ### Preparing files
 Put all documents you wish to convert into category folders within a folder in your docs list, called "DocsToConvertToMarkdown". Each category folder can contain multiple documents. You can use just one category folder, e.g. "default" if you don't want to use categories.

--- a/converttomarkdown.gapps
+++ b/converttomarkdown.gapps
@@ -391,7 +391,9 @@ function processParagraph(index, element, inSrc, imageCounter, listCounters, set
   
   //Paragraphs containing any text elements that look like a code block are code block lines
   } else if (anyCBL(settings, textElements, indented)) {
-    if (pOut.length > 1 && pOut.charAt(0) === "\t") {
+    //If paragraph is not indented, and is a CBL, then remove the leading tab if there
+    //is one, since it is there just to indicate a code block.
+    if (pOut.length > 1 && pOut.charAt(0) === "\t" && !indented) {
       pOut = pOut.slice(1);
     }
     result.text = pOut;
@@ -496,7 +498,7 @@ function findPrefix(inSrc, element, listCounters) {
 }
 
 //Transfer any leading spaces from inside to end of pre, and trailing spaces from inside to start of post,
-//so that bold/italics symbols are adjacent to the words they apply to, without intervening white space.
+//so that formatting symbols are adjacent to the words they apply to, without intervening white space.
 function compressInside(sections, blank) {
   while (sections.inside.substring(0, 1) == blank) {
     sections.pre = sections.pre + blank; 
@@ -563,7 +565,7 @@ function processTextElement(inSrc, txt, settings, inCodeBlock) {
       
       pOut = sections.pre + '[' + sections.inside + '](' + url + ')' + sections.post;
       
-    //Process font
+    //Process font for inline code
     } else if (!inSrc && isTextCourier(txt, off)) {
       // detect fonts that are in multiple pieces because of errors on formatting:
       while (i>=1 && isTextCourier(txt, attrs[i-1])) {
@@ -572,8 +574,18 @@ function processTextElement(inSrc, txt, settings, inCodeBlock) {
       }
       sections = makeSections(pOut, off, lastOff);
       
-      pOut = sections.pre + '`' + sections.inside + '`' + sections.post;
+      //Shrink bold/italic regions to reduce the whitespace they apply to.
+      compressInsideWhitespace(sections);
 
+      //If we have shrunk the formatted region to nothing, ignore it
+      if (sections.inside.length == 0) {
+        pOut = sections.pre + sections.post;
+        
+      //Apply formatting
+      } else {      
+        pOut = sections.pre + '`' + sections.inside + '`' + sections.post;      
+      }
+      
     //Process bold and/or italic. Note that this is only processed if this section is NOT
     //an URL or code.
     } else if (txt.isBold(off) || txt.isItalic(off)) {

--- a/converttomarkdown.gapps
+++ b/converttomarkdown.gapps
@@ -1,46 +1,92 @@
 /*
-Usage:
-  Add this script to a document (doesn't need to be the one you wish to export):
-    - Tools > Script Editor > New
-    - Select "Blank Project", then paste this code in and save.
+gdocs2md
+========
 
-  Preparing files:
-    - Put all documents you wish to convert into category folders within a folder in your docs list,
-      called "DocsToConvertToMarkdown". Each category folder can contain multiple documents. You can
-      use just one category folder, e.g. "default" if you don't want to use categories.
+A simple Google Apps script to convert a properly formatted Google Drive Document to the markdown (.md) format.
 
-  Running the script:
-    - Tools > Script Manager
-    - Select "convertDefaultFolder()" function.
-    - Click Run button.
-    - All documents in the folder will be converted to markdown,
-      and resulting files put in a new subfolder called "ExportedMarkdown-TIMESTAMP"
-      where TIMESTAMP is the current ISO GMT timestamp.
+## Usage
 
-  Settings:
-    There are several optional features, convertDefaultFolder() runs with most features enabled,
-    however most other functions take a settings object. The following fields should be set to true
-    to enable the corresponding features:
+### Adding to a document
+This script must be added to a document to run it - the document doesn't need to be the one you wish to export:
+ 1. Tools > Script Editor > New
+ 2. Select "Blank Project", then paste this code in and save.
 
-    - markdownTables - Output tables in GitHub-Flavoured Markdown rather than HTML. This also supports
-      bold and italic formatting, and inline code blocks, within table cells.
+### Preparing files
+Put all documents you wish to convert into category folders within a folder in your docs list, called "DocsToConvertToMarkdown". Each category folder can contain multiple documents. You can use just one category folder, e.g. "default" if you don't want to use categories.
 
-    - plainTextOutput - Output markdown to plaintext files (type "text/plain" with .txt extension),
-      allowing for viewing directly in Google Docs. If this is not specified, files will be have
-      type "text/x-markdown" and .md extension.
+### Running the script
+1. Tools > Script Manager
+2. Select "convertDefaultFolder()" function.
+3. Click Run button.
+4. All documents in the folder will be converted to markdown, and resulting files put in a new subfolder called "ExportedMarkdown-TIMESTAMP" where TIMESTAMP is the current ISO GMT timestamp.
 
-    - boldItalicIsQuote - Any lines starting with bold+italic formatting will become block quotes
-      in the markdown output.
+### Settings
+There are several optional features, convertDefaultFolder() runs with most features enabled, however most other functions take a settings object. The following fields should be set to true to enable the corresponding features:
+ * **markdownTables** - Output tables in GitHub-Flavoured Markdown rather than HTML. This also supports bold and italic formatting, and inline code blocks, within table cells.
 
-    - codeBlocks - Any lines starting with a tab and then containing at least one courier-new formatted
-      character will be considered as code lines. In addition, any empty or whitespace-only lines
-      following a code line will be considered to be code lines. Runs of code lines will be output with three
-      backticks before and after the run, and with the first tab (if any) removed from each line, to form a
-      standard markdown code block.
+ * **plainTextOutput** - Output markdown to plaintext files (type "text/plain" with .txt extension),allowing for viewing directly in Google Docs. If this is not specified, files will be have type "text/x-markdown" and .md extension.
 
-  Using different folders:
-    - You can call convertFolderByName(folderName, settings) with a different folder name as required
+ * **boldItalicIsQuote** - Any lines starting with bold+italic formatting will become block quotes in the markdown output.
 
+ * **codeBlocks** - Any lines starting with a tab and then containing at least one courier-new formatted character will be considered as code lines. In addition, any empty or whitespace-only lines following a code line will be considered to be code lines. Runs of code lines will be output with three backticks before and after the run, and with the first tab (if any) removed from each line, to form a standard markdown code block.
+
+### Using different folders
+You can call convertFolderByName(folderName, settings) with a different folder name as required
+
+### Miscellaneous
+There are also functions for emailing documents, see source for details.
+
+## Interpreted formats
+  * Text:
+    * paragraphs are separated by two newlines
+    * text styled as heading 1, 2, 3, etc is converted to Markdown heading: #, ##, ###, etc
+    * text formatted with Courier New is backquoted: ``text``
+    * links are converted to MD format: `[anchortext](url)`
+  * Lists:
+    * Numbered lists are converted correctly, including nested lists
+    * bullet lists are converted to "`*`" Markdown format appropriately, including nested lists
+  * Images:
+    * images are correctly extracted and sent as attachments
+  * Blocks:
+    * Table of contents is replaced by `[[TOC]]`
+    * blocks of text delimited by "--- class whateverclassnameyouwant" and "---" are converted to `<div class="whateverclassnameyouwant"></div>`
+    * Source code:
+      * **UPDATED**: blocks of text delimited by "--- source code" or "--- src" and "---" are converted to `<pre></pre>`
+      * **NEW**: blocks of text delimited by "--- source pretty" or "--- srcp" and "---" are converted to `<pre class="prettyprint"></pre>`
+    * Tables:
+      * **NEW**: Simple `<table>` processing
+  * "--- jsperf `<testID>`" is replaced by an iframe that shows an interactive chart of a JSPerf test. The `<testID>` is the last part of the URL of the Browserscope anchor in your JSPerf test. Something like `"agt1YS1wcm9maWxlcnINCxIEVGVzdBjlm_EQDA"` in the URL `http://www.browserscope.org/user/tests/table/agt1YS1wcm9maWxlcnINCxIEVGVzdBjlm_EQDA`
+
+## CONTRIBUTORS
+
+* Renato Mangini - [G+](//google.com/+renatomangini) - [Github](//github.com/mangini)
+* Ed Bacher - [G+](//plus.google.com/106923847899206957842) - [Github](//github.com/evbacher)
+* Ben Webster - [Github](//github.com/trepidacious)
+
+## LICENSE
+
+Use this script at your will, on any document you want and for any purpose, commercial or not.
+The MarkDown files generated by this script are not considered derivative work and
+don't require any attribution to the owners of this script.
+
+If you want to modify and redistribute the script (not the converted documents - those are yours),
+just keep a reference to this repo or to the license info below:
+
+```
+Copyright 2013 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```
 */
 
 function convertDefaultFolder() {

--- a/converttomarkdown.gapps
+++ b/converttomarkdown.gapps
@@ -5,8 +5,9 @@ Usage:
     - Select "Blank Project", then paste this code in and save.
     
   Preparing files:
-    - Put all documents you wish to convert into a folder in your docs list,
-      called "DocsToConvertToMarkdown"
+    - Put all documents you wish to convert into category folders within a folder in your docs list,
+      called "DocsToConvertToMarkdown". Each category folder can contain multiple documents. You can
+      use just one category folder, e.g. "default" if you don't want to use categories.
   
   Running the script:
     - Tools > Script Manager
@@ -22,35 +23,70 @@ Usage:
 */
 
 function convertDefaultFolder() {
-  convertFolder('DocsToConvertToMarkdown');
+  convertDownOneLevelByName('DocsToConvertToMarkdown');
 }
 
-function convertFolder(folderName) {
+function convertDownOneLevelByName(folderName) {
   var folder = DocsList.getFolder(folderName);
+  convertDownOneLevel(folder);  
+}
+
+function convertDownOneLevel(folder) {
+  var mainExportFolder = folder.createFolder(exportFolderName())
+  var folders = folder.getFolders();
+  for (var i in folders) {
+    var folder = folders[i];
+    if (folder.getName().substring(0, exportFolderPrefix.length) != exportFolderPrefix) {
+      var exportFolder = mainExportFolder.createFolder(folder.getName())
+      convertFolder(folder, exportFolder);
+    }
+  }
+}
+
+function convertFolderByName(folderName) {
+  var folder = DocsList.getFolder(folderName);
+  var exportFolder = folder.createFolder(exportFolderName())
+  convertFolder(folder, exportFolder);
+}
+
+function convertFolder(folder, exportFolder) {
   var files = folder.getFilesByType(DocsList.FileType.DOCUMENT);
-  var timeStamp = Utilities.formatDate(new Date(), "GMT", "yyyy-MM-dd'T'HH:mm:ss'Z'")
-  var exportFolder = folder.createFolder("ExportedMarkdown-" + timeStamp)
 
   var convertedDocNames = "";
   
   for (var i in files) {
     var doc = DocumentApp.openById(files[i].getId());
-    var attachments = convertToMarkdownAttachments(doc);
+    var converted = convertToMarkdownAttachments(doc);
     var docFolder = exportFolder.createFolder(doc.getName());
     convertedDocNames += doc.getName() + "\n";
-    for (var j in attachments) {
-      var attachment = attachments[j];
-      docFolder.createFile(attachment.fileName, attachment.content, attachment.mimeType);
-    }
-  }
 
+    // Write all files to target folder
+    for(var file in converted.files) {
+      file = converted.files[file];
+      var blob = file.blob.copyBlob();
+      var name = file.name; 
+      blob.setName(name); 
+      docFolder.createFile(blob); 
+    }
+    
+    // Write markdown file to target folder
+    docFolder.createFile(doc.getName() + ".md", converted.markdown, "text/x-markdown");  
+  }
+  
   //FIXME display some other way? Browser only works from a spreadsheet!
   //Browser.msgBox("Export complete", "Converted documents:\n" + convertedDocNames, Browser.Buttons.OK)
 }
 
+var exportFolderPrefix = "ExportedMarkdown-";
+
+function exportFolderName() {
+  var timeStamp = Utilities.formatDate(new Date(), "GMT", "yyyy-MM-dd'T'HH:mm:ss'Z'");
+  return exportFolderPrefix + timeStamp;
+}
+
 function mailActiveDocumentAsMarkdown() {
   var doc = DocumentApp.getActiveDocument();
-  var attachments = convertToMarkdownAttachments(doc);
+  var attachments = convertToMarkdownAttachments(doc).attachments;
   mailWithAttachments(doc, attachments);
 }
 
@@ -74,6 +110,7 @@ function convertToMarkdownAttachments(document) {
   var srcIndent = "";
   
   var attachments = [];
+  var files = [];
   
   // Walk through all the child elements of the doc.
   for (var i = 0; i < numChildren; i++) {
@@ -113,6 +150,12 @@ function convertToMarkdownAttachments(document) {
             "fileName": result.images[j].name,
             "mimeType": result.images[j].type,
             "content": result.images[j].bytes } );
+          
+          files.push( {
+            "name" : result.images[j].name,
+            "blob" : result.images[j].blob
+          });
+
         }
       }
     } else if (inSrc) { // support empty lines inside source code
@@ -123,7 +166,7 @@ function convertToMarkdownAttachments(document) {
   
   attachments.push({"fileName":document.getName()+".md", "mimeType": "text/x-markdown", "content": text});
 
-  return attachments;
+  return {attachments: attachments, files: files, markdown: text};
 }
 
 function escapeHTML(text) {
@@ -192,6 +235,7 @@ function processParagraph(index, element, inSrc, imageCounter, listCounters) {
       textElements.push('![image alt text]('+name+')');
       result.images.push( {
         "bytes": element.getChild(i).getBlob().getBytes(), 
+        "blob": element.getChild(i).getBlob(), 
         "type": contentType, 
         "name": name});
     } else if (t === DocumentApp.ElementType.PAGE_BREAK) {

--- a/converttomarkdown.gapps
+++ b/converttomarkdown.gapps
@@ -121,7 +121,7 @@ function convertToMarkdownAttachments(document) {
       
   }
   
-  attachments.push({"fileName":document.getName()+".md", "mimeType": "text/plain", "content": text});
+  attachments.push({"fileName":document.getName()+".md", "mimeType": "text/x-markdown", "content": text});
 
   return attachments;
 }

--- a/converttomarkdown.gapps
+++ b/converttomarkdown.gapps
@@ -1,17 +1,70 @@
 /*
 Usage: 
-  Adding this script to your doc: 
+  Add this script to a document (doesn't need to be the one you wish to export): 
     - Tools > Script Manager > New
     - Select "Blank Project", then paste this code in and save.
+    
+  Preparing files:
+    - Put all documents you wish to convert into a folder in your docs list,
+      called "DocsToConvertToMarkdown"
+  
   Running the script:
     - Tools > Script Manager
-    - Select "ConvertToMarkdown" function.
+    - Select "convertDefaultFolder" function.
     - Click Run button.
-    - Converted doc will be mailed to you. Subject will be "[MARKDOWN_MAKER]...".
+    - All documents in the folder will be converted to markdown,
+      and resulting files put in a new subfolder called "ExportedMarkdown-TIMESTAMP"
+      where TIMESTAMP is the current ISO GMT timestamp.
+      
+  Using different folders:
+    - You can call convertFolder(folderName) with a different folder name as required.
+    
 */
 
-function ConvertToMarkdown() {
-  var numChildren = DocumentApp.getActiveDocument().getActiveSection().getNumChildren();
+function convertDefaultFolder() {
+  convertFolder('DocsToConvertToMarkdown');
+}
+
+function convertFolder(folderName) {
+  var folder = DocsList.getFolder(folderName);
+  var files = folder.getFilesByType(DocsList.FileType.DOCUMENT);
+  var timeStamp = Utilities.formatDate(new Date(), "GMT", "yyyy-MM-dd'T'HH:mm:ss'Z'")
+  var exportFolder = folder.createFolder("ExportedMarkdown-" + timeStamp)
+
+  var convertedDocNames = "";
+  
+  for (var i in files) {
+    var doc = DocumentApp.openById(files[i].getId());
+    var attachments = convertToMarkdownAttachments(doc);
+    var docFolder = exportFolder.createFolder(doc.getName());
+    convertedDocNames += doc.getName() + "\n";
+    for (var j in attachments) {
+      var attachment = attachments[j];
+      docFolder.createFile(attachment.fileName, attachment.content, attachment.mimeType);
+    }
+  }
+
+  //FIXME display some other way? Browser only works from a spreadsheet!
+  //Browser.msgBox("Export complete", "Converted documents:\n" + convertedDocNames, Browser.Buttons.OK)
+}
+
+function mailActiveDocumentAsMarkdown() {
+  var doc = DocumentApp.getActiveDocument();
+  var attachments = convertToMarkdownAttachments(doc);
+  mailWithAttachments(doc, attachments);
+}
+
+function mailWithAttachments(document, attachments) {
+  MailApp.sendEmail(
+    Session.getActiveUser().getEmail(), 
+    "[MARKDOWN_MAKER] "+document.getName(), 
+    "Your converted markdown document is attached (converted from " + document.getUrl() + ")" +
+    "\n\nDon't know how to use the format options? See http://github.com/mangini/gdocs2md\n",
+    { "attachments": attachments });
+}
+
+function convertToMarkdownAttachments(document) {
+  var numChildren = document.getActiveSection().getNumChildren();
   var text = "";
   var inSrc = false;
   var inClass = false;
@@ -24,7 +77,7 @@ function ConvertToMarkdown() {
   
   // Walk through all the child elements of the doc.
   for (var i = 0; i < numChildren; i++) {
-    var child = DocumentApp.getActiveDocument().getActiveSection().getChild(i);
+    var child = document.getActiveSection().getChild(i);
     var result = processParagraph(i, child, inSrc, globalImageCounter, globalListCounters);
     globalImageCounter += (result && result.images) ? result.images.length : 0;
     if (result!==null) {
@@ -68,13 +121,9 @@ function ConvertToMarkdown() {
       
   }
   
-  attachments.push({"fileName":DocumentApp.getActiveDocument().getName()+".md", "mimeType": "text/plain", "content": text});
-  
-  MailApp.sendEmail(Session.getActiveUser().getEmail(), 
-                    "[MARKDOWN_MAKER] "+DocumentApp.getActiveDocument().getName(), 
-                    "Your converted markdown document is attached (converted from "+DocumentApp.getActiveDocument().getUrl()+")"+
-                    "\n\nDon't know how to use the format options? See http://github.com/mangini/gdocs2md\n",
-                    { "attachments": attachments });
+  attachments.push({"fileName":document.getName()+".md", "mimeType": "text/plain", "content": text});
+
+  return attachments;
 }
 
 function escapeHTML(text) {

--- a/converttomarkdown.gapps
+++ b/converttomarkdown.gapps
@@ -232,12 +232,9 @@ function processParagraph(index, element, inSrc, imageCounter, listCounters, set
   var pOut = "";
   var textElements = [];
   var imagePrefix = "image_";
-  
-//  Logger.log("New Paragraph");
-  
+    
   // First, check for things that require no processing.
   if (element.getNumChildren()==0) {
-//    Logger.log("element.getNumChildren()==0, inCodeBlock " + inCodeBlock);
     if (inCodeBlock) {
       result.text = "";
       result.cbl = true;
@@ -357,8 +354,6 @@ function processParagraph(index, element, inSrc, imageCounter, listCounters, set
   }
 
   if (textElements.length==0) {
-    Logger.log("textElements.length==0, inCodeBlock " + inCodeBlock);
-
     // Isn't result empty now?
     return result;
   }
@@ -381,9 +376,8 @@ function processParagraph(index, element, inSrc, imageCounter, listCounters, set
                   'src="http://www.html5rocks.com/static/jsperfview/embed.html?id='+RegExp.$1+
                   '"></iframe>';
   
-  //Paragraphs contianing any text elements that look like a code block are code block lines
+  //Paragraphs containing any text elements that look like a code block are code block lines
   } else if (anyCBL(settings, textElements)) {
-    Logger.log("CBL Paragraph: " + pOut);
     if (pOut.length > 1 && pOut.charAt(0) === "\t") {
       pOut = pOut.slice(1);
     }
@@ -515,10 +509,6 @@ function makeSections(pOut, off, lastOff) {
 }
 
 function processTextElement(inSrc, txt, settings, inCodeBlock) {
-
-//  if (typeof txt.getText == 'function') { 
-//    Logger.log("txt.getText: '" + txt.getText() + "'");
-//  }
 
   if (typeof(txt) === 'string') {
     return txt;

--- a/converttomarkdown.gapps
+++ b/converttomarkdown.gapps
@@ -31,9 +31,10 @@ function convertDownOneLevelByName(folderName) {
   convertDownOneLevel(folder);  
 }
 
-function convertDownOneLevel(folder) {
-  var mainExportFolder = folder.createFolder(exportFolderName())
-  var folders = folder.getFolders();
+function convertDownOneLevel(rootFolder) {
+  var mainExportFolder = rootFolder.createFolder(exportFolderName())
+  var folders = rootFolder.getFolders();
+  //Convert all folders that don't start with our export prefix
   for (var i in folders) {
     var folder = folders[i];
     if (folder.getName().substring(0, exportFolderPrefix.length) != exportFolderPrefix) {
@@ -41,6 +42,8 @@ function convertDownOneLevel(folder) {
       convertFolder(folder, exportFolder);
     }
   }
+  //Convert contents of the folder as well, mainly to catch any meta data
+  convertFolder(rootFolder, mainExportFolder);
 }
 
 function convertFolderByName(folderName) {

--- a/converttomarkdown.gapps
+++ b/converttomarkdown.gapps
@@ -1,14 +1,14 @@
 /*
-Usage: 
-  Add this script to a document (doesn't need to be the one you wish to export): 
+Usage:
+  Add this script to a document (doesn't need to be the one you wish to export):
     - Tools > Script Editor > New
     - Select "Blank Project", then paste this code in and save.
-    
+
   Preparing files:
     - Put all documents you wish to convert into category folders within a folder in your docs list,
       called "DocsToConvertToMarkdown". Each category folder can contain multiple documents. You can
       use just one category folder, e.g. "default" if you don't want to use categories.
-  
+
   Running the script:
     - Tools > Script Manager
     - Select "convertDefaultFolder()" function.
@@ -16,28 +16,28 @@ Usage:
     - All documents in the folder will be converted to markdown,
       and resulting files put in a new subfolder called "ExportedMarkdown-TIMESTAMP"
       where TIMESTAMP is the current ISO GMT timestamp.
-          
+
   Settings:
     There are several optional features, convertDefaultFolder() runs with most features enabled,
     however most other functions take a settings object. The following fields should be set to true
     to enable the corresponding features:
-      
+
     - markdownTables - Output tables in GitHub-Flavoured Markdown rather than HTML. This also supports
       bold and italic formatting, and inline code blocks, within table cells.
-      
-    - plainTextOutput - Output markdown to plaintext files (type "text/plain" with .txt extension), 
+
+    - plainTextOutput - Output markdown to plaintext files (type "text/plain" with .txt extension),
       allowing for viewing directly in Google Docs. If this is not specified, files will be have
       type "text/x-markdown" and .md extension.
-      
+
     - boldItalicIsQuote - Any lines starting with bold+italic formatting will become block quotes
       in the markdown output.
-      
+
     - codeBlocks - Any lines starting with a tab and then containing at least one courier-new formatted
       character will be considered as code lines. In addition, any empty or whitespace-only lines
       following a code line will be considered to be code lines. Runs of code lines will be output with three
-      backticks before and after the run, and with the first tab (if any) removed from each line, to form a 
+      backticks before and after the run, and with the first tab (if any) removed from each line, to form a
       standard markdown code block.
-  
+
   Using different folders:
     - You can call convertFolderByName(folderName, settings) with a different folder name as required
 
@@ -53,16 +53,20 @@ function convertDefaultFolderWithSettings(settings) {
 }
 
 function convertDownOneLevelByName(folderName, settings) {
-  var folder = DocsList.getFolder(folderName);
-  convertDownOneLevel(folder, settings);  
+  var folderIt = DriveApp.getFoldersByName(folderName);
+  if (folderIt.hasNext()) {
+    var folder = folderIt.next();
+    convertDownOneLevel(folder, settings);
+  }
 }
 
 function convertDownOneLevel(rootFolder, settings) {
+
   var mainExportFolder = rootFolder.createFolder(exportFolderName())
   var folders = rootFolder.getFolders();
   //Convert all folders that don't start with our export prefix
-  for (var i in folders) {
-    var folder = folders[i];
+  while (folders.hasNext()) {
+    var folder = folders.next();
     if (folder.getName().substring(0, exportFolderPrefix.length) != exportFolderPrefix) {
       var exportFolder = mainExportFolder.createFolder(folder.getName())
       convertFolder(folder, exportFolder, settings);
@@ -73,18 +77,22 @@ function convertDownOneLevel(rootFolder, settings) {
 }
 
 function convertFolderByName(folderName, settings) {
-  var folder = DocsList.getFolder(folderName);
-  var exportFolder = folder.createFolder(exportFolderName())
-  convertFolder(folder, exportFolder, settings);
+  var folderIt = DriveApp.getFoldersByName(folderName);
+  if (folderIt.hasNext()) {
+    var folder = folderIt.next();
+    var exportFolder = folder.createFolder(exportFolderName())
+    convertFolder(folder, exportFolder, settings);
+  }
 }
 
 function convertFolder(folder, exportFolder, settings) {
-  var files = folder.getFilesByType(DocsList.FileType.DOCUMENT);
+  var files = folder.getFilesByType(MimeType.GOOGLE_DOCS);
 
   var convertedDocNames = "";
-  
-  for (var i in files) {
-    var doc = DocumentApp.openById(files[i].getId());
+
+  while (files.hasNext()) {
+    var file = files.next();
+    var doc = DocumentApp.openById(file.getId());
     var converted = convertToMarkdownAttachments(doc, settings);
     var docFolder = exportFolder.createFolder(doc.getName());
     convertedDocNames += doc.getName() + "\n";
@@ -93,19 +101,19 @@ function convertFolder(folder, exportFolder, settings) {
     for(var file in converted.files) {
       file = converted.files[file];
       var blob = file.blob.copyBlob();
-      var name = file.name; 
-      blob.setName(name); 
-      docFolder.createFile(blob); 
+      var name = file.name;
+      blob.setName(name);
+      docFolder.createFile(blob);
     }
-    
+
     // Write markdown file to target folder
     if (settings.plainTextOutput) {
-      docFolder.createFile(doc.getName() + ".txt", converted.markdown, "text/plain");  
+      docFolder.createFile(doc.getName() + ".txt", converted.markdown, "text/plain");
     } else {
-      docFolder.createFile(doc.getName() + ".md", converted.markdown, "text/x-markdown");  
+      docFolder.createFile(doc.getName() + ".md", converted.markdown, "text/x-markdown");
     }
   }
-  
+
   //FIXME display some other way? Browser only works from a spreadsheet!
   //Browser.msgBox("Export complete", "Converted documents:\n" + convertedDocNames, Browser.Buttons.OK)
 }
@@ -125,8 +133,8 @@ function mailActiveDocumentAsMarkdown() {
 
 function mailWithAttachments(document, attachments) {
   MailApp.sendEmail(
-    Session.getActiveUser().getEmail(), 
-    "[MARKDOWN_MAKER] "+document.getName(), 
+    Session.getActiveUser().getEmail(),
+    "[MARKDOWN_MAKER] "+document.getName(),
     "Your converted markdown document is attached (converted from " + document.getUrl() + ")" +
     "\n\nDon't know how to use the format options? See http://github.com/mangini/gdocs2md\n",
     { "attachments": attachments });
@@ -142,29 +150,29 @@ function convertToMarkdownAttachments(document, settings) {
   var globalListCounters = {};
   // edbacher: added a variable for indent in src <pre> block. Let style sheet do margin.
   var srcIndent = "";
-  
+
   var attachments = [];
   var files = [];
-  
+
   // Walk through all the child elements of the doc.
   for (var i = 0; i < numChildren; i++) {
     var child = document.getActiveSection().getChild(i);
     var result = processParagraph(i, child, inSrc, globalImageCounter, globalListCounters, settings, inCodeBlock);
     globalImageCounter += (result && result.images) ? result.images.length : 0;
     if (result!==null) {
-      
+
       if (inCodeBlock && !result.cbl) {
         text+="```\n\n";
         inCodeBlock = false;
       }
-      
+
       if (result.cbl) {
         if (!inCodeBlock) {
           text+="\n```\n";
           inCodeBlock = true;
         }
         text+=result.text + "\n";
-        
+
       } else if (result.sourcePretty==="start" && !inSrc) {
         inSrc=true;
         text+="<pre class=\"prettyprint\">\n";
@@ -190,14 +198,14 @@ function convertToMarkdownAttachments(document, settings) {
       } else if (result.text && result.text.length>0) {
         text+=result.text+"\n\n";
       }
-      
+
       if (result.images && result.images.length>0) {
         for (var j=0; j<result.images.length; j++) {
           attachments.push( {
             "fileName": result.images[j].name,
             "mimeType": result.images[j].type,
             "content": result.images[j].bytes } );
-          
+
           files.push( {
             "name" : result.images[j].name,
             "blob" : result.images[j].blob
@@ -208,9 +216,9 @@ function convertToMarkdownAttachments(document, settings) {
     } else if (inSrc) { // support empty lines inside source code
       text+='\n';
     }
-      
+
   }
-  
+
   if (settings.plainTextOutput) {
     attachments.push({"fileName":document.getName()+".txt", "mimeType": "text/plain", "content": text});
   } else {
@@ -237,7 +245,7 @@ function processParagraph(index, element, inSrc, imageCounter, listCounters, set
   var textElements = [];
   var imagePrefix = "image_";
   var indented = false;
-    
+
   // First, check for things that require no processing.
   if (element.getNumChildren()==0) {
     if (inCodeBlock) {
@@ -247,13 +255,13 @@ function processParagraph(index, element, inSrc, imageCounter, listCounters, set
     } else {
       return null;
     }
-  }  
-  
+  }
+
   // Punt on TOC.
   if (element.getType() === DocumentApp.ElementType.TABLE_OF_CONTENTS) {
     return {"text": "[[TOC]]"};
   }
-  
+
   //Check for indent that can indicate code block etc.
   if (element.getType() === DocumentApp.ElementType.PARAGRAPH) {
     if (isNumber(settings.codeBlockMinIndent)) {
@@ -262,12 +270,12 @@ function processParagraph(index, element, inSrc, imageCounter, listCounters, set
       }
     }
   }
-  
+
   // Handle Table elements. Pretty simple-minded now, but works for simple tables.
-  // Note that Markdown does not process within block-level HTML, so it probably 
+  // Note that Markdown does not process within block-level HTML, so it probably
   // doesn't make sense to add markup within tables.
   if (element.getType() === DocumentApp.ElementType.TABLE) {
-    
+
     //Markdown table
     if (settings.markdownTables) {
       textElements.push("\n");
@@ -276,7 +284,7 @@ function processParagraph(index, element, inSrc, imageCounter, listCounters, set
         // process this row
         for (var j = 0; j < nCols; j++) {
           var cell = element.getChild(i).getChild(j);
-          
+
           //We expect the TableCell to have a single Paragraph child - if
           //so we will add all its text elements to our textElements array for
           //later processing
@@ -291,11 +299,11 @@ function processParagraph(index, element, inSrc, imageCounter, listCounters, set
               }
             }
           }
-            
+
           if (j < nCols - 1) textElements.push(" | ");
         }
         textElements.push("\n");
-        
+
         //Line of row separators after first row (assumed to be table headings)
         if (i == 0) {
           for (var j = 0; j < nCols; j++) {
@@ -304,9 +312,9 @@ function processParagraph(index, element, inSrc, imageCounter, listCounters, set
           }
           textElements.push("\n");
         }
-      }      
+      }
       textElements.push("\n");
-      
+
     //HTML table
     } else {
       textElements.push("<table>\n");
@@ -322,11 +330,11 @@ function processParagraph(index, element, inSrc, imageCounter, listCounters, set
       textElements.push("</table>\n");
     }
   }
-  
+
   // Process various types (ElementType).
   for (var i = 0; i < element.getNumChildren(); i++) {
     var t=element.getChild(i).getType();
-    
+
     if (t === DocumentApp.ElementType.TABLE_ROW) {
       // do nothing: already handled TABLE_ROW
     } else if (t === DocumentApp.ElementType.TEXT) {
@@ -350,9 +358,9 @@ function processParagraph(index, element, inSrc, imageCounter, listCounters, set
       imageCounter++;
       textElements.push('![image alt text]('+name+')');
       result.images.push( {
-        "bytes": element.getChild(i).getBlob().getBytes(), 
-        "blob": element.getChild(i).getBlob(), 
-        "type": contentType, 
+        "bytes": element.getChild(i).getBlob().getBytes(),
+        "blob": element.getChild(i).getBlob(),
+        "type": contentType,
         "name": name});
     } else if (t === DocumentApp.ElementType.PAGE_BREAK) {
       // ignore
@@ -370,7 +378,7 @@ function processParagraph(index, element, inSrc, imageCounter, listCounters, set
     // Isn't result empty now?
     return result;
   }
-  
+
   // evb: Add source pretty too. (And abbreviations: src and srcp.)
   // process source code block:
   if (/^\s*---\s+srcp\s*$/.test(pOut) || /^\s*---\s+source pretty\s*$/.test(pOut)) {
@@ -388,7 +396,7 @@ function processParagraph(index, element, inSrc, imageCounter, listCounters, set
     result.text = '<iframe style="width: 100%; height: 340px; overflow: hidden; border: 0;" '+
                   'src="http://www.html5rocks.com/static/jsperfview/embed.html?id='+RegExp.$1+
                   '"></iframe>';
-  
+
   //Paragraphs containing any text elements that look like a code block are code block lines
   } else if (anyCBL(settings, textElements, indented)) {
     //If paragraph is not indented, and is a CBL, then remove the leading tab if there
@@ -398,31 +406,31 @@ function processParagraph(index, element, inSrc, imageCounter, listCounters, set
     }
     result.text = pOut;
     result.cbl = true;
-    
+
   //Blank paragraphs following a code block are part of the code block
   } else if (inCodeBlock && pOut.trim().length == 0) {
     result.text = "";
     result.cbl = true;
-    
+
   } else {
 
     prefix = findPrefix(inSrc, element, listCounters);
-  
+
     var pOut = "";
-    
+
     for (var i=0; i<textElements.length; i++) {
       var txt = textElements[i];
 
       var processed = processTextElement(inSrc, textElements[i], settings, inCodeBlock);
       pOut += processed;//.markdown;
     }
-    
+
     // replace Unicode quotation marks
     pOut = pOut.replace('\u201d', '"').replace('\u201c', '"');
- 
+
     result.text = prefix+pOut;
   }
-  
+
   return result;
 }
 
@@ -442,7 +450,7 @@ function isCBL(settings, txt, indented) {
   if (typeof(txt) === 'string') {
     return false;
   }
-  
+
   var cbl = false;
 
   if (settings.codeBlocks && ((txt.getText().length > 1 && txt.getText().charAt(0) === "\t") || indented)) {
@@ -450,9 +458,9 @@ function isCBL(settings, txt, indented) {
       if (isTextCourier(txt, c)) {
         cbl = true;
       }
-    }    
+    }
   }
-  
+
   return cbl;
 }
 
@@ -501,7 +509,7 @@ function findPrefix(inSrc, element, listCounters) {
 //so that formatting symbols are adjacent to the words they apply to, without intervening white space.
 function compressInside(sections, blank) {
   while (sections.inside.substring(0, 1) == blank) {
-    sections.pre = sections.pre + blank; 
+    sections.pre = sections.pre + blank;
     sections.inside = sections.inside.substring(1);
   }
   while (sections.inside.substring(sections.inside.length - 1) == blank) {
@@ -533,15 +541,15 @@ function processTextElement(inSrc, txt, settings, inCodeBlock) {
   if (typeof(txt) === 'string') {
     return txt;
   }
-  
+
   var pOut = txt.getText();
   if (! txt.getTextAttributeIndices) {
     return pOut;
   }
-  
+
   //Get the offsets within the text where text formatting runs start
   var attrs=txt.getTextAttributeIndices();
-    
+
   //Previous offset processed, starts at end of text
   var lastOff=pOut.length;
 
@@ -562,9 +570,9 @@ function processTextElement(inSrc, txt, settings, inCodeBlock) {
         url=txt.getLinkUrl(off);
         sections = makeSections(pOut, off, lastOff);
       }
-      
+
       pOut = sections.pre + '[' + sections.inside + '](' + url + ')' + sections.post;
-      
+
     //Process font for inline code
     } else if (!inSrc && isTextCourier(txt, off)) {
       // detect fonts that are in multiple pieces because of errors on formatting:
@@ -573,29 +581,29 @@ function processTextElement(inSrc, txt, settings, inCodeBlock) {
         off=attrs[i];
       }
       sections = makeSections(pOut, off, lastOff);
-      
+
       //Shrink bold/italic regions to reduce the whitespace they apply to.
       compressInsideWhitespace(sections);
 
       //If we have shrunk the formatted region to nothing, ignore it
       if (sections.inside.length == 0) {
         pOut = sections.pre + sections.post;
-        
+
       //Apply formatting
-      } else {      
-        pOut = sections.pre + '`' + sections.inside + '`' + sections.post;      
+      } else {
+        pOut = sections.pre + '`' + sections.inside + '`' + sections.post;
       }
-      
+
     //Process bold and/or italic. Note that this is only processed if this section is NOT
     //an URL or code.
     } else if (txt.isBold(off) || txt.isItalic(off)) {
-      
+
       //FIXME can we use the same "multiple pieces" code above to prevent errors in runs of the same
       //bold/italic state with redundant attributes in the middle?
-      
+
       var bold = txt.isBold(off);
       var italic = txt.isItalic(off);
-      
+
       // Expand run of formatting backwards, if bold/italic state is the same. Not sure why, but Docs occasionally have
       // redundant formatting, most notably around colons.
       while (i>=1 && (txt.isBold(attrs[i-1]) === bold) && (txt.isItalic(attrs[i-1]) === italic)) {
@@ -603,32 +611,32 @@ function processTextElement(inSrc, txt, settings, inCodeBlock) {
         off=attrs[i];
       }
       sections = makeSections(pOut, off, lastOff);
-      
+
       var d1 = d2 = "*";
-      
+
       if (bold) {
-        var d1 = d2 = "**"  
+        var d1 = d2 = "**"
         if (italic) {
           d1 = "**_"; d2 = "_**";
         }
       }
-      
+
       //Shrink bold/italic regions to reduce the whitespace they apply to.
       compressInsideWhitespace(sections);
-      
+
       //If we have shrunk the formatted region to nothing, ignore it
       if (sections.inside.length == 0) {
         pOut = sections.pre + sections.post;
-        
+
       //Apply formatting
-      } else {      
-        pOut = sections.pre + d1 + sections.inside + d2 + sections.post;      
+      } else {
+        pOut = sections.pre + d1 + sections.inside + d2 + sections.post;
       }
     }
-    
+
     lastOff=off;
   }
-  
+
   //Format any text that starts with bold italic as a quote
   if (settings.boldItalicIsQuote && txt.getText().length > 0 && txt.isBold(0) && txt.isItalic(0)) {
     pOut = "> " + pOut;

--- a/converttomarkdown.gapps
+++ b/converttomarkdown.gapps
@@ -44,7 +44,7 @@ Usage:
 */
 
 function convertDefaultFolder() {
-  var settings = {markdownTables: true, plainTextOutput: false, boldItalicIsQuote: true, codeBlocks: true};
+  var settings = {markdownTables: true, plainTextOutput: false, boldItalicIsQuote: true, codeBlocks: true, codeBlockMinIndent: 12};
   convertDefaultFolderWithSettings(settings);
 }
 
@@ -224,6 +224,10 @@ function escapeHTML(text) {
   return text.replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 
+function isNumber(n) {
+  return !isNaN(parseFloat(n)) && isFinite(n);
+}
+
 // Process each child element (not just paragraphs).
 function processParagraph(index, element, inSrc, imageCounter, listCounters, settings, inCodeBlock) {
 
@@ -232,6 +236,7 @@ function processParagraph(index, element, inSrc, imageCounter, listCounters, set
   var pOut = "";
   var textElements = [];
   var imagePrefix = "image_";
+  var indented = false;
     
   // First, check for things that require no processing.
   if (element.getNumChildren()==0) {
@@ -249,6 +254,14 @@ function processParagraph(index, element, inSrc, imageCounter, listCounters, set
     return {"text": "[[TOC]]"};
   }
   
+  //Check for indent that can indicate code block etc.
+  if (element.getType() === DocumentApp.ElementType.PARAGRAPH) {
+    if (isNumber(settings.codeBlockMinIndent)) {
+      if (element.getIndentStart() > settings.codeBlockMinIndent) {
+        indented = true;
+      }
+    }
+  }
   
   // Handle Table elements. Pretty simple-minded now, but works for simple tables.
   // Note that Markdown does not process within block-level HTML, so it probably 
@@ -377,7 +390,7 @@ function processParagraph(index, element, inSrc, imageCounter, listCounters, set
                   '"></iframe>';
   
   //Paragraphs containing any text elements that look like a code block are code block lines
-  } else if (anyCBL(settings, textElements)) {
+  } else if (anyCBL(settings, textElements, indented)) {
     if (pOut.length > 1 && pOut.charAt(0) === "\t") {
       pOut = pOut.slice(1);
     }
@@ -411,23 +424,28 @@ function processParagraph(index, element, inSrc, imageCounter, listCounters, set
   return result;
 }
 
-function anyCBL(settings, txts) {
+function isTextCourier(txt, c) {
+  return (txt.getFontFamily(c) == DocumentApp.FontFamily.COURIER_NEW);
+}
+
+function anyCBL(settings, txts, indented) {
   for (var i=0; i<txts.length; i++) {
     var txt = txts[i];
-    if (isCBL(settings, txt)) return true;
+    if (isCBL(settings, txt, indented)) return true;
   }
   return false;
 }
 
-function isCBL(settings, txt) {
+function isCBL(settings, txt, indented) {
   if (typeof(txt) === 'string') {
     return false;
   }
+  
+  var cbl = false;
 
-  if (settings.codeBlocks && txt.getText().length > 1 && txt.getText().charAt(0) === "\t") {
-    var cbl = false;
+  if (settings.codeBlocks && ((txt.getText().length > 1 && txt.getText().charAt(0) === "\t") || indented)) {
     for (var c = 0; c < txt.getText().length; c++) {
-      if (txt.getFontFamily(c)===DocumentApp.FontFamily.COURIER_NEW) {
+      if (isTextCourier(txt, c)) {
         cbl = true;
       }
     }    
@@ -530,7 +548,6 @@ function processTextElement(inSrc, txt, settings, inCodeBlock) {
     //Start of formatting run
     var off=attrs[i];
     var url=txt.getLinkUrl(off);
-    var font=txt.getFontFamily(off);
 
     var sections = makeSections(pOut, off, lastOff);
 
@@ -547,9 +564,9 @@ function processTextElement(inSrc, txt, settings, inCodeBlock) {
       pOut = sections.pre + '[' + sections.inside + '](' + url + ')' + sections.post;
       
     //Process font
-    } else if (font && !inSrc && font===font.COURIER_NEW) {
+    } else if (!inSrc && isTextCourier(txt, off)) {
       // detect fonts that are in multiple pieces because of errors on formatting:
-      while (i>=1 && txt.getFontFamily(attrs[i-1]) && txt.getFontFamily(attrs[i-1])===font.COURIER_NEW) {
+      while (i>=1 && isTextCourier(txt, attrs[i-1])) {
         i-=1;
         off=attrs[i];
       }

--- a/converttomarkdown.gapps
+++ b/converttomarkdown.gapps
@@ -1,7 +1,7 @@
 /*
 Usage: 
   Add this script to a document (doesn't need to be the one you wish to export): 
-    - Tools > Script Manager > New
+    - Tools > Script Editor > New
     - Select "Blank Project", then paste this code in and save.
     
   Preparing files:
@@ -11,27 +11,53 @@ Usage:
   
   Running the script:
     - Tools > Script Manager
-    - Select "convertDefaultFolder" function.
+    - Select "convertDefaultFolder()" function.
     - Click Run button.
     - All documents in the folder will be converted to markdown,
       and resulting files put in a new subfolder called "ExportedMarkdown-TIMESTAMP"
       where TIMESTAMP is the current ISO GMT timestamp.
+          
+  Settings:
+    There are several optional features, convertDefaultFolder() runs with most features enabled,
+    however most other functions take a settings object. The following fields should be set to true
+    to enable the corresponding features:
       
+    - markdownTables - Output tables in GitHub-Flavoured Markdown rather than HTML. This also supports
+      bold and italic formatting, and inline code blocks, within table cells.
+      
+    - plainTextOutput - Output markdown to plaintext files (type "text/plain" with .txt extension), 
+      allowing for viewing directly in Google Docs. If this is not specified, files will be have
+      type "text/x-markdown" and .md extension.
+      
+    - boldItalicIsQuote - Any lines starting with bold+italic formatting will become block quotes
+      in the markdown output.
+      
+    - codeBlocks - Any lines starting with a tab and then containing at least one courier-new formatted
+      character will be considered as code lines. In addition, any empty or whitespace-only lines
+      following a code line will be considered to be code lines. Runs of code lines will be output with three
+      backticks before and after the run, and with the first tab (if any) removed from each line, to form a 
+      standard markdown code block.
+  
   Using different folders:
-    - You can call convertFolder(folderName) with a different folder name as required.
-    
+    - You can call convertFolderByName(folderName, settings) with a different folder name as required
+
 */
 
 function convertDefaultFolder() {
-  convertDownOneLevelByName('DocsToConvertToMarkdown');
+  var settings = {markdownTables: true, plainTextOutput: false, boldItalicIsQuote: true, codeBlocks: true};
+  convertDefaultFolderWithSettings(settings);
 }
 
-function convertDownOneLevelByName(folderName) {
+function convertDefaultFolderWithSettings(settings) {
+  convertDownOneLevelByName('DocsToConvertToMarkdown', settings);
+}
+
+function convertDownOneLevelByName(folderName, settings) {
   var folder = DocsList.getFolder(folderName);
-  convertDownOneLevel(folder);  
+  convertDownOneLevel(folder, settings);  
 }
 
-function convertDownOneLevel(rootFolder) {
+function convertDownOneLevel(rootFolder, settings) {
   var mainExportFolder = rootFolder.createFolder(exportFolderName())
   var folders = rootFolder.getFolders();
   //Convert all folders that don't start with our export prefix
@@ -39,27 +65,27 @@ function convertDownOneLevel(rootFolder) {
     var folder = folders[i];
     if (folder.getName().substring(0, exportFolderPrefix.length) != exportFolderPrefix) {
       var exportFolder = mainExportFolder.createFolder(folder.getName())
-      convertFolder(folder, exportFolder);
+      convertFolder(folder, exportFolder, settings);
     }
   }
   //Convert contents of the folder as well, mainly to catch any meta data
-  convertFolder(rootFolder, mainExportFolder);
+  convertFolder(rootFolder, mainExportFolder, settings);
 }
 
-function convertFolderByName(folderName) {
+function convertFolderByName(folderName, settings) {
   var folder = DocsList.getFolder(folderName);
   var exportFolder = folder.createFolder(exportFolderName())
-  convertFolder(folder, exportFolder);
+  convertFolder(folder, exportFolder, settings);
 }
 
-function convertFolder(folder, exportFolder) {
+function convertFolder(folder, exportFolder, settings) {
   var files = folder.getFilesByType(DocsList.FileType.DOCUMENT);
 
   var convertedDocNames = "";
   
   for (var i in files) {
     var doc = DocumentApp.openById(files[i].getId());
-    var converted = convertToMarkdownAttachments(doc);
+    var converted = convertToMarkdownAttachments(doc, settings);
     var docFolder = exportFolder.createFolder(doc.getName());
     convertedDocNames += doc.getName() + "\n";
 
@@ -73,7 +99,11 @@ function convertFolder(folder, exportFolder) {
     }
     
     // Write markdown file to target folder
-    docFolder.createFile(doc.getName() + ".md", converted.markdown, "text/x-markdown");  
+    if (settings.plainTextOutput) {
+      docFolder.createFile(doc.getName() + ".txt", converted.markdown, "text/plain");  
+    } else {
+      docFolder.createFile(doc.getName() + ".md", converted.markdown, "text/x-markdown");  
+    }
   }
   
   //FIXME display some other way? Browser only works from a spreadsheet!
@@ -102,10 +132,11 @@ function mailWithAttachments(document, attachments) {
     { "attachments": attachments });
 }
 
-function convertToMarkdownAttachments(document) {
+function convertToMarkdownAttachments(document, settings) {
   var numChildren = document.getActiveSection().getNumChildren();
   var text = "";
   var inSrc = false;
+  var inCodeBlock = false;
   var inClass = false;
   var globalImageCounter = 0;
   var globalListCounters = {};
@@ -118,10 +149,23 @@ function convertToMarkdownAttachments(document) {
   // Walk through all the child elements of the doc.
   for (var i = 0; i < numChildren; i++) {
     var child = document.getActiveSection().getChild(i);
-    var result = processParagraph(i, child, inSrc, globalImageCounter, globalListCounters);
+    var result = processParagraph(i, child, inSrc, globalImageCounter, globalListCounters, settings, inCodeBlock);
     globalImageCounter += (result && result.images) ? result.images.length : 0;
     if (result!==null) {
-      if (result.sourcePretty==="start" && !inSrc) {
+      
+      if (inCodeBlock && !result.cbl) {
+        text+="```\n\n";
+        inCodeBlock = false;
+      }
+      
+      if (result.cbl) {
+        if (!inCodeBlock) {
+          text+="\n```\n";
+          inCodeBlock = true;
+        }
+        text+=result.text + "\n";
+        
+      } else if (result.sourcePretty==="start" && !inSrc) {
         inSrc=true;
         text+="<pre class=\"prettyprint\">\n";
       } else if (result.sourcePretty==="end" && inSrc) {
@@ -167,7 +211,11 @@ function convertToMarkdownAttachments(document) {
       
   }
   
-  attachments.push({"fileName":document.getName()+".md", "mimeType": "text/x-markdown", "content": text});
+  if (settings.plainTextOutput) {
+    attachments.push({"fileName":document.getName()+".txt", "mimeType": "text/plain", "content": text});
+  } else {
+    attachments.push({"fileName":document.getName()+".md", "mimeType": "text/x-markdown", "content": text});
+  }
 
   return {attachments: attachments, files: files, markdown: text};
 }
@@ -177,37 +225,92 @@ function escapeHTML(text) {
 }
 
 // Process each child element (not just paragraphs).
-function processParagraph(index, element, inSrc, imageCounter, listCounters) {
-  // First, check for things that require no processing.
-  if (element.getNumChildren()==0) {
-    return null;
-  }  
-  // Punt on TOC.
-  if (element.getType() === DocumentApp.ElementType.TABLE_OF_CONTENTS) {
-    return {"text": "[[TOC]]"};
-  }
-  
+function processParagraph(index, element, inSrc, imageCounter, listCounters, settings, inCodeBlock) {
+
   // Set up for real results.
   var result = {};
   var pOut = "";
   var textElements = [];
   var imagePrefix = "image_";
   
+//  Logger.log("New Paragraph");
+  
+  // First, check for things that require no processing.
+  if (element.getNumChildren()==0) {
+//    Logger.log("element.getNumChildren()==0, inCodeBlock " + inCodeBlock);
+    if (inCodeBlock) {
+      result.text = "";
+      result.cbl = true;
+      return result;
+    } else {
+      return null;
+    }
+  }  
+  
+  // Punt on TOC.
+  if (element.getType() === DocumentApp.ElementType.TABLE_OF_CONTENTS) {
+    return {"text": "[[TOC]]"};
+  }
+  
+  
   // Handle Table elements. Pretty simple-minded now, but works for simple tables.
   // Note that Markdown does not process within block-level HTML, so it probably 
   // doesn't make sense to add markup within tables.
   if (element.getType() === DocumentApp.ElementType.TABLE) {
-    textElements.push("<table>\n");
-    var nCols = element.getChild(0).getNumCells();
-    for (var i = 0; i < element.getNumChildren(); i++) {
-      textElements.push("  <tr>\n");
-      // process this row
-      for (var j = 0; j < nCols; j++) {
-        textElements.push("    <td>" + element.getChild(i).getChild(j).getText() + "</td>\n");
+    
+    //Markdown table
+    if (settings.markdownTables) {
+      textElements.push("\n");
+      var nCols = element.getChild(0).getNumCells();
+      for (var i = 0; i < element.getNumChildren(); i++) {
+        // process this row
+        for (var j = 0; j < nCols; j++) {
+          var cell = element.getChild(i).getChild(j);
+          
+          //We expect the TableCell to have a single Paragraph child - if
+          //so we will add all its text elements to our textElements array for
+          //later processing
+          if (cell.getNumChildren() > 0) {
+            var cellPara = cell.getChild(0);
+            if (cellPara.getType() === DocumentApp.ElementType.PARAGRAPH) {
+              for (var k = 0; k < cellPara.getNumChildren(); k++) {
+                var el = cellPara.getChild(k);
+                if (el.getType() === DocumentApp.ElementType.TEXT) {
+                  textElements.push(el);
+                }
+              }
+            }
+          }
+            
+          if (j < nCols - 1) textElements.push(" | ");
+        }
+        textElements.push("\n");
+        
+        //Line of row separators after first row (assumed to be table headings)
+        if (i == 0) {
+          for (var j = 0; j < nCols; j++) {
+            textElements.push("---");
+            if (j < nCols - 1) textElements.push(" | ");
+          }
+          textElements.push("\n");
+        }
+      }      
+      textElements.push("\n");
+      
+    //HTML table
+    } else {
+      textElements.push("<table>\n");
+      var nCols = element.getChild(0).getNumCells();
+      for (var i = 0; i < element.getNumChildren(); i++) {
+        textElements.push("  <tr>\n");
+        // process this row
+        for (var j = 0; j < nCols; j++) {
+          textElements.push("    <td>" + element.getChild(i).getChild(j).getText() + "</td>\n");
+        }
+        textElements.push("  </tr>\n");
       }
-      textElements.push("  </tr>\n");
+      textElements.push("</table>\n");
     }
-    textElements.push("</table>\n");
   }
   
   // Process various types (ElementType).
@@ -254,6 +357,8 @@ function processParagraph(index, element, inSrc, imageCounter, listCounters) {
   }
 
   if (textElements.length==0) {
+    Logger.log("textElements.length==0, inCodeBlock " + inCodeBlock);
+
     // Isn't result empty now?
     return result;
   }
@@ -275,15 +380,34 @@ function processParagraph(index, element, inSrc, imageCounter, listCounters) {
     result.text = '<iframe style="width: 100%; height: 340px; overflow: hidden; border: 0;" '+
                   'src="http://www.html5rocks.com/static/jsperfview/embed.html?id='+RegExp.$1+
                   '"></iframe>';
+  
+  //Paragraphs contianing any text elements that look like a code block are code block lines
+  } else if (anyCBL(settings, textElements)) {
+    Logger.log("CBL Paragraph: " + pOut);
+    if (pOut.length > 1 && pOut.charAt(0) === "\t") {
+      pOut = pOut.slice(1);
+    }
+    result.text = pOut;
+    result.cbl = true;
+    
+  //Blank paragraphs following a code block are part of the code block
+  } else if (inCodeBlock && pOut.trim().length == 0) {
+    result.text = "";
+    result.cbl = true;
+    
   } else {
 
     prefix = findPrefix(inSrc, element, listCounters);
   
     var pOut = "";
+    
     for (var i=0; i<textElements.length; i++) {
-      pOut += processTextElement2(inSrc, textElements[i]);
-    }
+      var txt = textElements[i];
 
+      var processed = processTextElement(inSrc, textElements[i], settings, inCodeBlock);
+      pOut += processed;//.markdown;
+    }
+    
     // replace Unicode quotation marks
     pOut = pOut.replace('\u201d', '"').replace('\u201c', '"');
  
@@ -291,6 +415,31 @@ function processParagraph(index, element, inSrc, imageCounter, listCounters) {
   }
   
   return result;
+}
+
+function anyCBL(settings, txts) {
+  for (var i=0; i<txts.length; i++) {
+    var txt = txts[i];
+    if (isCBL(settings, txt)) return true;
+  }
+  return false;
+}
+
+function isCBL(settings, txt) {
+  if (typeof(txt) === 'string') {
+    return false;
+  }
+
+  if (settings.codeBlocks && txt.getText().length > 1 && txt.getText().charAt(0) === "\t") {
+    var cbl = false;
+    for (var c = 0; c < txt.getText().length; c++) {
+      if (txt.getFontFamily(c)===DocumentApp.FontFamily.COURIER_NEW) {
+        cbl = true;
+      }
+    }    
+  }
+  
+  return cbl;
 }
 
 // Add correct prefix to list items.
@@ -356,7 +505,21 @@ function compressInsideWhitespace(sections) {
   compressInside(sections, "\f");
 }
 
-function processTextElement2(inSrc, txt) {
+function makeSections(pOut, off, lastOff) {
+  var sections = {
+      inside: pOut.substring(off, lastOff),
+      pre: pOut.substring(0, off),
+      post: pOut.substring(lastOff)
+    };
+  return sections;
+}
+
+function processTextElement(inSrc, txt, settings, inCodeBlock) {
+
+//  if (typeof txt.getText == 'function') { 
+//    Logger.log("txt.getText: '" + txt.getText() + "'");
+//  }
+
   if (typeof(txt) === 'string') {
     return txt;
   }
@@ -368,8 +531,6 @@ function processTextElement2(inSrc, txt) {
   
   //Get the offsets within the text where text formatting runs start
   var attrs=txt.getTextAttributeIndices();
-
-  var s = "";
     
   //Previous offset processed, starts at end of text
   var lastOff=pOut.length;
@@ -381,42 +542,54 @@ function processTextElement2(inSrc, txt) {
     var url=txt.getLinkUrl(off);
     var font=txt.getFontFamily(off);
 
-    var sections = {
-      inside: pOut.substring(off, lastOff),
-      pre: pOut.substring(0, off),
-      post: pOut.substring(lastOff)
-    }
+    var sections = makeSections(pOut, off, lastOff);
 
     //Process URL
     if (url) {  // start of link
+      // detect links that are in multiple pieces because of errors on formatting:
       if (i>=1 && attrs[i-1]==off-1 && txt.getLinkUrl(attrs[i-1])===url) {
-        // detect links that are in multiple pieces because of errors on formatting:
         i-=1;
         off=attrs[i];
         url=txt.getLinkUrl(off);
+        sections = makeSections(pOut, off, lastOff);
       }
+      
       pOut = sections.pre + '[' + sections.inside + '](' + url + ')' + sections.post;
       
     //Process font
-    } else if (font) {
-      if (!inSrc && font===font.COURIER_NEW) {
-        while (i>=1 && txt.getFontFamily(attrs[i-1]) && txt.getFontFamily(attrs[i-1])===font.COURIER_NEW) {
-          // detect fonts that are in multiple pieces because of errors on formatting:
-          i-=1;
-          off=attrs[i];
-        }
-        pOut = sections.pre + '`' + sections.inside + '`' + sections.post;
+    } else if (font && !inSrc && font===font.COURIER_NEW) {
+      // detect fonts that are in multiple pieces because of errors on formatting:
+      while (i>=1 && txt.getFontFamily(attrs[i-1]) && txt.getFontFamily(attrs[i-1])===font.COURIER_NEW) {
+        i-=1;
+        off=attrs[i];
       }
-    }
-    
-    //Process bold and/or italic
-    if (txt.isBold(off) || txt.isItalic(off)) {
+      sections = makeSections(pOut, off, lastOff);
+      
+      pOut = sections.pre + '`' + sections.inside + '`' + sections.post;
+
+    //Process bold and/or italic. Note that this is only processed if this section is NOT
+    //an URL or code.
+    } else if (txt.isBold(off) || txt.isItalic(off)) {
+      
+      //FIXME can we use the same "multiple pieces" code above to prevent errors in runs of the same
+      //bold/italic state with redundant attributes in the middle?
+      
+      var bold = txt.isBold(off);
+      var italic = txt.isItalic(off);
+      
+      // Expand run of formatting backwards, if bold/italic state is the same. Not sure why, but Docs occasionally have
+      // redundant formatting, most notably around colons.
+      while (i>=1 && (txt.isBold(attrs[i-1]) === bold) && (txt.isItalic(attrs[i-1]) === italic)) {
+        i-=1;
+        off=attrs[i];
+      }
+      sections = makeSections(pOut, off, lastOff);
       
       var d1 = d2 = "*";
       
-      if (txt.isBold(off)) {
+      if (bold) {
         var d1 = d2 = "**"  
-        if (txt.isItalic(off)) {
+        if (italic) {
           d1 = "**_"; d2 = "_**";
         }
       }
@@ -436,69 +609,11 @@ function processTextElement2(inSrc, txt) {
     
     lastOff=off;
   }
-  return pOut;
-}
+  
+  //Format any text that starts with bold italic as a quote
+  if (settings.boldItalicIsQuote && txt.getText().length > 0 && txt.isBold(0) && txt.isItalic(0)) {
+    pOut = "> " + pOut;
+  }
 
-function processTextElement(inSrc, txt) {
-  if (typeof(txt) === 'string') {
-    return txt;
-  }
-  
-  var pOut = txt.getText();
-  if (! txt.getTextAttributeIndices) {
-    return pOut;
-  }
-  
-  //Get the offsets within the text where text formatting runs start
-  var attrs=txt.getTextAttributeIndices();
-  
-  //Previous offset processed, starts at end of text
-  var lastOff=pOut.length;
-
-  //Process the text string in formatting runs, backwards
-  for (var i=attrs.length-1; i>=0; i--) {
-    //Start of formatting run
-    var off=attrs[i];
-    var url=txt.getLinkUrl(off);
-    var font=txt.getFontFamily(off);
-    
-    //Process URL
-    if (url) {  // start of link
-      if (i>=1 && attrs[i-1]==off-1 && txt.getLinkUrl(attrs[i-1])===url) {
-        // detect links that are in multiple pieces because of errors on formatting:
-        i-=1;
-        off=attrs[i];
-        url=txt.getLinkUrl(off);
-      }
-      pOut=pOut.substring(0, off)+'['+pOut.substring(off, lastOff)+']('+url+')'+pOut.substring(lastOff);
-      
-    //Process font
-    } else if (font) {
-      if (!inSrc && font===font.COURIER_NEW) {
-        while (i>=1 && txt.getFontFamily(attrs[i-1]) && txt.getFontFamily(attrs[i-1])===font.COURIER_NEW) {
-          // detect fonts that are in multiple pieces because of errors on formatting:
-          i-=1;
-          off=attrs[i];
-        }
-        pOut=pOut.substring(0, off)+'`'+pOut.substring(off, lastOff)+'`'+pOut.substring(lastOff);
-      }
-    }
-    
-    //Process bold and bold italic
-    if (txt.isBold(off)) {
-      var d1 = d2 = "**";
-      if (txt.isItalic(off)) {
-        // edbacher: changed this to handle bold italic properly.
-        d1 = "**_"; d2 = "_**";
-      }
-      pOut=pOut.substring(0, off)+d1+pOut.substring(off, lastOff)+d2+pOut.substring(lastOff);
-      
-    //Process italic
-    } else if (txt.isItalic(off)) {
-      pOut=pOut.substring(0, off)+'*'+pOut.substring(off, lastOff)+'*'+pOut.substring(lastOff);
-    }
-    
-    lastOff=off;
-  }
   return pOut;
 }

--- a/converttomarkdown.gapps
+++ b/converttomarkdown.gapps
@@ -234,7 +234,7 @@ function processParagraph(index, element, inSrc, imageCounter, listCounters) {
   
     var pOut = "";
     for (var i=0; i<textElements.length; i++) {
-      pOut += processTextElement(inSrc, textElements[i]);
+      pOut += processTextElement2(inSrc, textElements[i]);
     }
 
     // replace Unicode quotation marks
@@ -287,6 +287,111 @@ function findPrefix(inSrc, element, listCounters) {
   return prefix;
 }
 
+//Transfer any leading spaces from inside to end of pre, and trailing spaces from inside to start of post,
+//so that bold/italics symbols are adjacent to the words they apply to, without intervening white space.
+function compressInside(sections, blank) {
+  while (sections.inside.substring(0, 1) == blank) {
+    sections.pre = sections.pre + blank; 
+    sections.inside = sections.inside.substring(1);
+  }
+  while (sections.inside.substring(sections.inside.length - 1) == blank) {
+    sections.post = blank + sections.post;
+    sections.inside = sections.inside.substring(0, sections.inside.length - 1);
+  }
+}
+
+//Compress inside using spaces, tabs, carriage returns, newlines and form feeds.
+function compressInsideWhitespace(sections) {
+  compressInside(sections, " ");
+  compressInside(sections, "\t");
+  compressInside(sections, "\r");
+  compressInside(sections, "\n");
+  compressInside(sections, "\f");
+}
+
+function processTextElement2(inSrc, txt) {
+  if (typeof(txt) === 'string') {
+    return txt;
+  }
+  
+  var pOut = txt.getText();
+  if (! txt.getTextAttributeIndices) {
+    return pOut;
+  }
+  
+  //Get the offsets within the text where text formatting runs start
+  var attrs=txt.getTextAttributeIndices();
+
+  var s = "";
+    
+  //Previous offset processed, starts at end of text
+  var lastOff=pOut.length;
+
+  //Process the text string in formatting runs, backwards
+  for (var i=attrs.length-1; i>=0; i--) {
+    //Start of formatting run
+    var off=attrs[i];
+    var url=txt.getLinkUrl(off);
+    var font=txt.getFontFamily(off);
+
+    var sections = {
+      inside: pOut.substring(off, lastOff),
+      pre: pOut.substring(0, off),
+      post: pOut.substring(lastOff)
+    }
+
+    //Process URL
+    if (url) {  // start of link
+      if (i>=1 && attrs[i-1]==off-1 && txt.getLinkUrl(attrs[i-1])===url) {
+        // detect links that are in multiple pieces because of errors on formatting:
+        i-=1;
+        off=attrs[i];
+        url=txt.getLinkUrl(off);
+      }
+      pOut = sections.pre + '[' + sections.inside + '](' + url + ')' + sections.post;
+      
+    //Process font
+    } else if (font) {
+      if (!inSrc && font===font.COURIER_NEW) {
+        while (i>=1 && txt.getFontFamily(attrs[i-1]) && txt.getFontFamily(attrs[i-1])===font.COURIER_NEW) {
+          // detect fonts that are in multiple pieces because of errors on formatting:
+          i-=1;
+          off=attrs[i];
+        }
+        pOut = sections.pre + '`' + sections.inside + '`' + sections.post;
+      }
+    }
+    
+    //Process bold and/or italic
+    if (txt.isBold(off) || txt.isItalic(off)) {
+      
+      var d1 = d2 = "*";
+      
+      if (txt.isBold(off)) {
+        var d1 = d2 = "**"  
+        if (txt.isItalic(off)) {
+          d1 = "**_"; d2 = "_**";
+        }
+      }
+      
+      //Shrink bold/italic regions to reduce the whitespace they apply to.
+      compressInsideWhitespace(sections);
+      
+      //If we have shrunk the formatted region to nothing, ignore it
+      if (sections.inside.length == 0) {
+        pOut = sections.pre + sections.post;
+        
+      //Apply formatting
+      } else {      
+        pOut = sections.pre + d1 + sections.inside + d2 + sections.post;      
+      }
+    }
+    
+    lastOff=off;
+  }
+  return pOut;
+}
+
 function processTextElement(inSrc, txt) {
   if (typeof(txt) === 'string') {
     return txt;
@@ -297,13 +402,20 @@ function processTextElement(inSrc, txt) {
     return pOut;
   }
   
+  //Get the offsets within the text where text formatting runs start
   var attrs=txt.getTextAttributeIndices();
+  
+  //Previous offset processed, starts at end of text
   var lastOff=pOut.length;
 
+  //Process the text string in formatting runs, backwards
   for (var i=attrs.length-1; i>=0; i--) {
+    //Start of formatting run
     var off=attrs[i];
     var url=txt.getLinkUrl(off);
     var font=txt.getFontFamily(off);
+    
+    //Process URL
     if (url) {  // start of link
       if (i>=1 && attrs[i-1]==off-1 && txt.getLinkUrl(attrs[i-1])===url) {
         // detect links that are in multiple pieces because of errors on formatting:
@@ -312,6 +424,8 @@ function processTextElement(inSrc, txt) {
         url=txt.getLinkUrl(off);
       }
       pOut=pOut.substring(0, off)+'['+pOut.substring(off, lastOff)+']('+url+')'+pOut.substring(lastOff);
+      
+    //Process font
     } else if (font) {
       if (!inSrc && font===font.COURIER_NEW) {
         while (i>=1 && txt.getFontFamily(attrs[i-1]) && txt.getFontFamily(attrs[i-1])===font.COURIER_NEW) {
@@ -322,6 +436,8 @@ function processTextElement(inSrc, txt) {
         pOut=pOut.substring(0, off)+'`'+pOut.substring(off, lastOff)+'`'+pOut.substring(lastOff);
       }
     }
+    
+    //Process bold and bold italic
     if (txt.isBold(off)) {
       var d1 = d2 = "**";
       if (txt.isItalic(off)) {
@@ -329,9 +445,12 @@ function processTextElement(inSrc, txt) {
         d1 = "**_"; d2 = "_**";
       }
       pOut=pOut.substring(0, off)+d1+pOut.substring(off, lastOff)+d2+pOut.substring(lastOff);
+      
+    //Process italic
     } else if (txt.isItalic(off)) {
       pOut=pOut.substring(0, off)+'*'+pOut.substring(off, lastOff)+'*'+pOut.substring(lastOff);
     }
+    
     lastOff=off;
   }
   return pOut;

--- a/converttomarkdown.js
+++ b/converttomarkdown.js
@@ -9,7 +9,7 @@ A simple Google Apps script to convert a properly formatted Google Drive Documen
 ### Adding to a document
 This script must be added to a document to run it - the document doesn't need to be the one you wish to export:
  1. Tools > Script Editor > New
- 2. Select "Blank Project", then paste this code in and save.
+ 2. Select "Blank Project", then paste the code from converttomarkdown.js into it and save.
 
 ### Preparing files
 Put all documents you wish to convert into category folders within a folder in your docs list, called "DocsToConvertToMarkdown". Each category folder can contain multiple documents. You can use just one category folder, e.g. "default" if you don't want to use categories.


### PR DESCRIPTION
Hi,
Thanks for the converter - just what we needed to get a more useful document format out of Google Drive!

We had some minor problems with the export, where some of our documents had odd italic and bold formatting, which covered leading/trailing whitespace (sometimes even JUST whitespace, e.g. a single "italic" space between words). Since this is invisible in the original documents it's hard to correct.

Commit c72c363 deals with this by shrinking the regions of bold and italic formatting to remove leading/trailing whitespace, which removes useless formatting and also makes the output more compliant with markdown.

I've also included commits to make the converter more flexible, by allowing exporting to new files in your drive, and to use a new mimeType so that e.g. stackedit.io will see the files. This also means that when they are downloaded, they have just an "md" extension, not ".md.txt". Finally, it makes nested italic and bold a little neater by breaking up the asterisks so it's easier to read.

Let me know if you would prefer a pull request for just the italic/bold. I've also got a Drive document with some examples of odd formatting that is fixed by the changes. I don't think the changes should break anything, but I could have missed a possibility.

Thanks,
Ben.
