### PR TITLE
Changes prefix for ordered list from a correct number to "1. "

### DIFF
--- a/converttomarkdown.gapps
+++ b/converttomarkdown.gapps
@@ -51,7 +51,18 @@ function ConvertToMarkdown() {
       } else if (inSrc) {
         text+=(srcIndent+escapeHTML(result.text)+"\n");
       } else if (result.text && result.text.length>0) {
-        text+=result.text+"\n\n";
+        // SM-Mark: Only insert a blank line when this is the last list item
+        if (child.getType()!==DocumentApp.ElementType.LIST_ITEM) {
+          text+=result.text+"\n\n";
+        } else {
+          text+=result.text+"\n";
+          if (i < numChildren - 1) {
+            var nextChild = DocumentApp.getActiveDocument().getActiveSection().getChild(i+1);
+            if (nextChild.getType()!==DocumentApp.ElementType.LIST_ITEM) {
+              text+="\n";
+            }
+          }
+        }
       }
       
       if (result.images && result.images.length>0) {
@@ -182,7 +193,7 @@ function processParagraph(index, element, inSrc, imageCounter, listCounters) {
   } else {
 
     prefix = findPrefix(inSrc, element, listCounters);
-  
+
     var pOut = "";
     for (var i=0; i<textElements.length; i++) {
       pOut += processTextElement(inSrc, textElements[i]);

--- a/converttomarkdown.gapps
+++ b/converttomarkdown.gapps
@@ -235,7 +235,7 @@ function findPrefix(inSrc, element, listCounters) {
       if (gt === DocumentApp.GlyphType.BULLET
           || gt === DocumentApp.GlyphType.HOLLOW_BULLET
           || gt === DocumentApp.GlyphType.SQUARE_BULLET) {
-        prefix += "* ";
+        prefix += "- ";
       } else {
         // Ordered list (<ol>):
         prefix = "1. ";

--- a/converttomarkdown.gapps
+++ b/converttomarkdown.gapps
@@ -227,11 +227,7 @@ function findPrefix(inSrc, element, listCounters) {
         prefix += "* ";
       } else {
         // Ordered list (<ol>):
-        var key = listItem.getListId() + '.' + listItem.getNestingLevel();
-        var counter = listCounters[key] || 0;
-        counter++;
-        listCounters[key] = counter;
-        prefix += counter+". ";
+        prefix = "1. ";
       }
     }
   }


### PR DESCRIPTION
Changes prefix for ordered list from a correct number to "1. " which markdown renderers will number correctly. This simplifies adding additional list items after being converted to markdown.
