### PR TITLE
Support courier new

### DIFF
--- a/converttomarkdown.gapps
+++ b/converttomarkdown.gapps
@@ -264,8 +264,8 @@ function processTextElement(inSrc, txt) {
       }
       pOut=pOut.substring(0, off)+'['+pOut.substring(off, lastOff)+']('+url+')'+pOut.substring(lastOff);
     } else if (font) {
-      if (!inSrc && font===font.COURIER_NEW) {
-        while (i>=1 && txt.getFontFamily(attrs[i-1]) && txt.getFontFamily(attrs[i-1])===font.COURIER_NEW) {
+      if (!inSrc && font==="Courier New") {
+        while (i>=1 && txt.getFontFamily(attrs[i-1]) && txt.getFontFamily(attrs[i-1])==="Courier New") {
           // detect fonts that are in multiple pieces because of errors on formatting:
           i-=1;
           off=attrs[i];


### PR DESCRIPTION
Hi!

I am by no means familiar with Google Apps scripts, but I can see the detection of Courier New fonts doesn't work for me unless I put the explicit name "Courier New".
Also, this page seems to say that the enum is deprecated anyway: https://developers.google.com/apps-script/reference/document/font-family

This proposed fix did the job for me but please comment if a better alternative exists!

Thanks for the great job anyway.